### PR TITLE
建议修复出现只订阅一个库中部分表时数据同步不及时的问题

### DIFF
--- a/server/to_server_consume.go
+++ b/server/to_server_consume.go
@@ -2,15 +2,16 @@ package server
 
 import (
 	"fmt"
-	"github.com/brokercap/Bifrost/plugin"
-	pluginDriver "github.com/brokercap/Bifrost/plugin/driver"
-	"github.com/brokercap/Bifrost/server/warning"
 	"io"
 	"log"
 	"runtime"
 	"runtime/debug"
 	"time"
+
 	"github.com/brokercap/Bifrost/config"
+	"github.com/brokercap/Bifrost/plugin"
+	pluginDriver "github.com/brokercap/Bifrost/plugin/driver"
+	"github.com/brokercap/Bifrost/server/warning"
 )
 
 // 暂停操作
@@ -18,12 +19,12 @@ func (This *ToServer) Stop() {
 	This.Lock()
 	defer This.Unlock()
 	if This.Status == "" {
-		log.Println("ToServer ",*This.Key,This.ToServerKey,This.ToServerID," stopped")
+		log.Println("ToServer ", *This.Key, This.ToServerKey, This.ToServerID, " stopped")
 		This.Status = STOPPED
 		return
 	}
 	if This.Status == RUNNING {
-		log.Println("ToServer ",*This.Key,This.ToServerKey,This.ToServerID," stopping")
+		log.Println("ToServer ", *This.Key, This.ToServerKey, This.ToServerID, " stopping")
 		This.Status = STOPPING
 		return
 	}
@@ -36,25 +37,25 @@ func (This *ToServer) Start() {
 	if This.Status == STOPPED {
 		if This.ThreadCount == 0 {
 			This.Status = DEFAULT
-		}else{
+		} else {
 			This.statusChan <- true
 		}
-		log.Println("ToServer ",*This.Key,This.ToServerKey,This.ToServerID," start")
+		log.Println("ToServer ", *This.Key, This.ToServerKey, This.ToServerID, " start")
 	}
 }
 
-func (This *ToServer) ConsumeToServer(db *db,SchemaName string,TableName string)  {
-	This.consume_to_server(db,SchemaName,TableName)
+func (This *ToServer) ConsumeToServer(db *db, SchemaName string, TableName string) {
+	This.consume_to_server(db, SchemaName, TableName)
 }
 
-func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName string) {
+func (This *ToServer) consume_to_server(db *db, SchemaName string, TableName string) {
 	var MyConsumerId int
 	This.Lock()
-	if This.cosumerPluginParamArr == nil{
-		This.cosumerPluginParamArr = make([]interface{},0)
+	if This.cosumerPluginParamArr == nil {
+		This.cosumerPluginParamArr = make([]interface{}, 0)
 	}
 	This.ThreadCount++
-	This.cosumerPluginParamArr = append(This.cosumerPluginParamArr,nil)
+	This.cosumerPluginParamArr = append(This.cosumerPluginParamArr, nil)
 	MyConsumerId = len(This.cosumerPluginParamArr) - 1
 	//强制给参数 加入  BifrostMustBeSuccess 保留参数字段
 	if This.PluginParam != nil {
@@ -62,37 +63,37 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 		This.PluginParam["BifrostFilterQuery"] = This.FilterQuery
 	}
 	This.Unlock()
-	toServerPositionBinlogKey := getToServerBinlogkey(db,This)
+	toServerPositionBinlogKey := getToServerBinlogkey(db, This)
 	// 因为有多个地方对 ThreadCount - 1 操作，记录是否已经扣减过
 	var ThreadCountDecrDone bool = false
 	defer func() {
-		if err := recover();err !=nil{
-			log.Println(db.Name,This.Notes,"toServerKey:",*This.Key,"MyConsumerId:",MyConsumerId,"SchemaName:",SchemaName,"TableName:",TableName, This.PluginName,This.ToServerKey,"ToServer consume_to_server over;err:",err,"debug",string(debug.Stack()))
+		if err := recover(); err != nil {
+			log.Println(db.Name, This.Notes, "toServerKey:", *This.Key, "MyConsumerId:", MyConsumerId, "SchemaName:", SchemaName, "TableName:", TableName, This.PluginName, This.ToServerKey, "ToServer consume_to_server over;err:", err, "debug", string(debug.Stack()))
 			return
-		}else{
-			log.Println(db.Name,This.Notes,"toServerKey:",*This.Key,"MyConsumerId:",MyConsumerId,"SchemaName:",SchemaName,"TableName:",TableName, This.PluginName,This.ToServerKey,"ToServer consume_to_server over")
+		} else {
+			log.Println(db.Name, This.Notes, "toServerKey:", *This.Key, "MyConsumerId:", MyConsumerId, "SchemaName:", SchemaName, "TableName:", TableName, This.PluginName, This.ToServerKey, "ToServer consume_to_server over")
 		}
 		This.Lock()
-		if ThreadCountDecrDone == false{
+		if ThreadCountDecrDone == false {
 			This.ThreadCount--
 		}
 		if This.ThreadCount == 0 {
 			This.cosumerPluginParamArr = nil
-		}else{
+		} else {
 			This.cosumerPluginParamArr[MyConsumerId] = nil
 		}
 		This.Unlock()
 	}()
-	log.Println(db.Name,This.Notes,"toServerKey:",*This.Key,"MyConsumerId:",MyConsumerId,"SchemaName:",SchemaName,"TableName:",TableName, This.PluginName,This.ToServerKey,"ToServer consume_to_server  start")
+	log.Println(db.Name, This.Notes, "toServerKey:", *This.Key, "MyConsumerId:", MyConsumerId, "SchemaName:", SchemaName, "TableName:", TableName, This.PluginName, This.ToServerKey, "ToServer consume_to_server  start")
 	c := This.ToServerChan.To
 	This.Lock()
 	if This.Status == DEFAULT {
 		This.Status = RUNNING
 	}
 	This.Unlock()
-	var CheckStatusFun = func(){
-		for{
-			if db.killStatus == 1{
+	var CheckStatusFun = func() {
+		for {
+			if db.killStatus == 1 {
 				runtime.Goexit()
 			}
 			This.Lock()
@@ -103,7 +104,7 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 				This.Unlock()
 				runtime.Goexit()
 				break
-			case STOPPING,STOPPED:
+			case STOPPING, STOPPED:
 				if This.Status == STOPPING {
 					//检测是否需要在暂停操作，如果是暂停操作，则修改为已暂停状态，并且等待开启
 					This.Status = STOPPED
@@ -111,12 +112,12 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 				}
 				This.Unlock()
 				select {
-				case <- This.statusChan:
+				case <-This.statusChan:
 					This.Lock()
 					This.Status = RUNNING
 					This.Unlock()
 					return
-				case <- time.NewTimer(5 * time.Second).C:
+				case <-time.NewTimer(5 * time.Second).C:
 					break
 				}
 			default:
@@ -128,12 +129,12 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 	var LastSuccessData *pluginDriver.PluginDataType
 	var ErrData *pluginDriver.PluginDataType
 	var errs error
-	binlogKey := getToServerBinlogkey(db,This)
+	binlogKey := getToServerBinlogkey(db, This)
 
 	var SaveBinlog = func() {
 		if LastSuccessData != nil {
 			switch LastSuccessData.EventType {
-			case "commit","sql":
+			case "commit", "sql":
 				break
 			default:
 				return
@@ -143,11 +144,11 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 			//db.Unlock()
 			//这里保存位点是为了刷到磁盘,这个位点在重启 配置文件恢复的时候，会根据最小的 ToServerList 的位点进行自动替换
 			var LastSuccessBinlog = &PositionStruct{
-				BinlogFileNum: LastSuccessData.BinlogFileNum,
+				BinlogFileNum:  LastSuccessData.BinlogFileNum,
 				BinlogPosition: LastSuccessData.BinlogPosition,
-				GTID: LastSuccessData.Gtid,
-				Timestamp: LastSuccessData.Timestamp,
-				EventID: LastSuccessData.EventID,
+				GTID:           LastSuccessData.Gtid,
+				Timestamp:      LastSuccessData.Timestamp,
+				EventID:        LastSuccessData.EventID,
 			}
 
 			This.LastSuccessBinlog = LastSuccessBinlog
@@ -163,7 +164,7 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 	var warningStatus bool = false
 
 	//告警方法
-	var doWarningFun = func(warningType warning.WarningType,body string) {
+	var doWarningFun = func(warningType warning.WarningType, body string) {
 		if warningType == warning.WARNINGNORMAL && warningStatus != true {
 			return
 		}
@@ -178,15 +179,15 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 	}
 	var noData bool = true
 
-	var unack int = 0      // 在一次遍历中从文件队列中加载出来的数量，需要
-	var tmpUnack int = 0   // 在一次遍历中从文件队列中加载出来 但是实际位点是被成功处理过后的 数量
-	var lastFromFileEndData *pluginDriver.PluginDataType		// 从文件队列中加载出来的最后 最后一条数据
+	var unack int = 0                                    // 在一次遍历中从文件队列中加载出来的数量，需要
+	var tmpUnack int = 0                                 // 在一次遍历中从文件队列中加载出来 但是实际位点是被成功处理过后的 数量
+	var lastFromFileEndData *pluginDriver.PluginDataType // 从文件队列中加载出来的最后 最后一条数据
 	var fileTotalCount int = 0
 	var fileAck = func() {
 		if LastSuccessData == nil {
 			return
 		}
-		if unack == 0{
+		if unack == 0 {
 			return
 		}
 		if This.fileQueueObj == nil {
@@ -204,24 +205,24 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 			return
 		}
 		if LastSuccessData.BinlogFileNum == lastFromFileEndData.BinlogFileNum {
-			if LastSuccessData.BinlogPosition >= lastFromFileEndData.BinlogPosition{
+			if LastSuccessData.BinlogPosition >= lastFromFileEndData.BinlogPosition {
 				//log.Println("file ackn2:",unack," and unack:",unack," fileTotalCount:",fileTotalCount)
 				This.fileQueueObj.Ack(unack)
 				unack = 0
-			}else{
+			} else {
 				This.fileQueueObj.Ack(1)
 				unack--
 				//log.Println("file ack1:",1," and unack:",unack," fileTotalCount:",fileTotalCount)
 			}
-		}else{
+		} else {
 			return
 		}
 	}
 	var checkDoWarning = func() {
 		// lastErrTime 是指第一次错误的时间,假如报警过后,将 lastErrTime 修改为1小时后,这样就可以实现最近一小时,同一个错误不会重复报警了
-		if time.Now().Unix() - lastErrTime >= 30 {
+		if time.Now().Unix()-lastErrTime >= 30 {
 			lastErrTime = time.Now().Unix() + 3600
-			doWarningFun(warning.WARNINGERROR,"PluginName:"+This.PluginName+";ToServerKey:"+This.ToServerKey+" err:"+errs.Error())
+			doWarningFun(warning.WARNINGERROR, "PluginName:"+This.PluginName+";ToServerKey:"+This.ToServerKey+" err:"+errs.Error())
 		}
 	}
 	var retry = false
@@ -245,14 +246,14 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 		retry = false
 		for {
 			errs = nil
-			LastSuccessData,ErrData,errs = This.sendToServer(data,MyConsumerId,retry)
+			LastSuccessData, ErrData, errs = This.sendToServer(data, MyConsumerId, retry)
 			if This.MustBeSuccess == true {
 				if errs == nil {
 					if lastErrTime > 0 {
 						This.DelWaitError()
 						lastErrTime = 0
 						//自动恢复
-						doWarningFun(warning.WARNINGNORMAL,"Automatically return to normal")
+						doWarningFun(warning.WARNINGNORMAL, "Automatically return to normal")
 					}
 					fileAck()
 					break
@@ -280,7 +281,7 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 					checkDoWarning()
 				}
 				retry = true
-			}else{
+			} else {
 				LastSuccessData = nil
 				fileAck()
 				break
@@ -298,15 +299,15 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 		if This.FileQueueStatus && This.QueueMsgCount == 0 {
 			//这要问我这里为什么 -1, 因为我不知道 在同一个线程里写满后再消费，会不会进入 chan 死锁的情况
 			queueVariableSize := config.ToServerQueueSize - 1
-			if queueVariableSize > 0{
+			if queueVariableSize > 0 {
 				This.InitFileQueue(db.Name, SchemaName, TableName)
 				//log.Println("file ack2:",unack," fileTotalCount:",fileTotalCount)
 				This.fileQueueObj.Ack(unack)
 				tmpUnack = 0
 				unack = 0
-				log.Println(db.Name, SchemaName, TableName,This.PluginName,This.ToServerKey,"ToServer consume_to_server start PopFileQueue")
+				log.Println(db.Name, SchemaName, TableName, This.PluginName, This.ToServerKey, "ToServer consume_to_server start PopFileQueue")
 				var err error
-				for i:=0; i < queueVariableSize; i++ {
+				for i := 0; i < queueVariableSize; i++ {
 					var data0 *pluginDriver.PluginDataType
 					data0, err = This.PopFileQueue()
 					if err != nil && err != io.EOF {
@@ -351,70 +352,70 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 			}
 		}
 		var data *pluginDriver.PluginDataType
-		timer.Reset(time.Duration(config.PluginCommitTimeOut) * time.Second)
+		//timer.Reset(time.Duration(config.PluginCommitTimeOut) * time.Second)
 		select {
-		case data = <- c:
+		case data = <-c:
 			This.Lock()
 			This.QueueMsgCount--
 			This.Unlock()
 			noData = false
 			CheckStatusFun()
 			warningStatus = false
-			timer.Stop()
+			// timer.Stop()
 			switch data.EventType {
 			case "sql":
 				forSendData(data)
 				break
-			case "insert","delete":
+			case "insert", "delete":
 				n1 = len(data.Rows)
-				if n1 > 1{
+				if n1 > 1 {
 					n0 = 0
-					for _,v := range data.Rows{
+					for _, v := range data.Rows {
 						n0++
 						d := &pluginDriver.PluginDataType{
-							Timestamp:data.Timestamp,
-							EventType:data.EventType,
-							Query:"",
-							SchemaName:data.SchemaName,
-							TableName:data.TableName,
-							BinlogFileNum:0,
-							BinlogPosition:0,
-							Rows:make([]map[string]interface{},1),
-							Gtid: data.Gtid,
-							Pri: data.Pri,
-							ColumnMapping: data.ColumnMapping,
-							EventID: data.EventID,
+							Timestamp:      data.Timestamp,
+							EventType:      data.EventType,
+							Query:          "",
+							SchemaName:     data.SchemaName,
+							TableName:      data.TableName,
+							BinlogFileNum:  0,
+							BinlogPosition: 0,
+							Rows:           make([]map[string]interface{}, 1),
+							Gtid:           data.Gtid,
+							Pri:            data.Pri,
+							ColumnMapping:  data.ColumnMapping,
+							EventID:        data.EventID,
 						}
-						if n0 == n1{
+						if n0 == n1 {
 							d.BinlogFileNum = data.BinlogFileNum
 							d.BinlogPosition = data.BinlogPosition
 						}
 						d.Rows[0] = v
 						forSendData(d)
 					}
-				}else{
+				} else {
 					forSendData(data)
 				}
 				break
 			case "update":
 				n1 = len(data.Rows)
-				if n1 > 2{
-					for n0 = 0;n0 < n1;n0+=2{
+				if n1 > 2 {
+					for n0 = 0; n0 < n1; n0 += 2 {
 						d := &pluginDriver.PluginDataType{
-							Timestamp:data.Timestamp,
-							EventType:data.EventType,
-							Query:"",
-							SchemaName:data.SchemaName,
-							TableName:data.TableName,
-							BinlogFileNum:0,
-							BinlogPosition:0,
-							Rows:make([]map[string]interface{},2),
-							Gtid: data.Gtid,
-							Pri: data.Pri,
-							ColumnMapping: data.ColumnMapping,
-							EventID: data.EventID,
+							Timestamp:      data.Timestamp,
+							EventType:      data.EventType,
+							Query:          "",
+							SchemaName:     data.SchemaName,
+							TableName:      data.TableName,
+							BinlogFileNum:  0,
+							BinlogPosition: 0,
+							Rows:           make([]map[string]interface{}, 2),
+							Gtid:           data.Gtid,
+							Pri:            data.Pri,
+							ColumnMapping:  data.ColumnMapping,
+							EventID:        data.EventID,
 						}
-						if n0 == n1-2{
+						if n0 == n1-2 {
 							d.BinlogFileNum = data.BinlogFileNum
 							d.BinlogPosition = data.BinlogPosition
 						}
@@ -422,7 +423,7 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 						d.Rows[1] = data.Rows[n0+1]
 						forSendData(d)
 					}
-				}else{
+				} else {
 					forSendData(data)
 				}
 				break
@@ -435,7 +436,7 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 			break
 		case <-timer.C:
 			timer.Stop()
-			LastSuccessData, ErrData,errs = This.timeOutCommit(MyConsumerId)
+			LastSuccessData, ErrData, errs = This.timeOutCommit(MyConsumerId)
 			if errs == nil {
 				if lastErrTime > 0 {
 					This.DelWaitError()
@@ -453,12 +454,12 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 					checkDealSkipErrData()
 				}
 			}
-			if noData == false{
+			if noData == false {
 				noData = true
-				log.Println("consume_to_server:",This.Notes,"toServerKey:",*This.Key,"MyConsumerId:",MyConsumerId,This.PluginName,This.ToServerKey,This.ToServerID," start no data")
+				log.Println("consume_to_server:", This.Notes, "toServerKey:", *This.Key, "MyConsumerId:", MyConsumerId, This.PluginName, This.ToServerKey, This.ToServerID, " start no data")
 			}
 			fileAck()
-			if LastSuccessData == nil && errs == nil{
+			if LastSuccessData == nil && errs == nil {
 				This.Lock()
 				if This.QueueMsgCount == 0 {
 					// 在全量任务的时候，有可能是起多个消费者,所以这里要判断一下，是不是只剩下一个消费者，只有一个消费者的时候的时候,再将 chan 关闭
@@ -478,18 +479,19 @@ func (This *ToServer) consume_to_server(db *db,SchemaName string,TableName strin
 				This.Unlock()
 			}
 			SaveBinlog()
+			timer.Reset(time.Duration(config.PluginCommitTimeOut) * time.Second)
 			break
 		}
 	}
 }
 
-func (This *ToServer) filterField(data *pluginDriver.PluginDataType)(newData *pluginDriver.PluginDataType,b bool) {
+func (This *ToServer) filterField(data *pluginDriver.PluginDataType) (newData *pluginDriver.PluginDataType, b bool) {
 	n := len(data.Rows)
-	if n == 0{
-		return data,true
+	if n == 0 {
+		return data, true
 	}
-	if len(This.FieldList) == 0{
-		return data,true
+	if len(This.FieldList) == 0 {
+		return data, true
 	}
 
 	if n == 1 {
@@ -500,32 +502,32 @@ func (This *ToServer) filterField(data *pluginDriver.PluginDataType)(newData *pl
 			}
 		}
 		newData = &pluginDriver.PluginDataType{
-			Timestamp:data.Timestamp,
-			EventType:data.EventType,
-			SchemaName:data.SchemaName,
-			TableName:data.TableName,
-			BinlogFileNum:data.BinlogFileNum,
-			BinlogPosition:data.BinlogPosition,
-			Rows:make([]map[string]interface{},1),
-			Gtid: data.Gtid,
-			Pri: data.Pri,
-			ColumnMapping: data.ColumnMapping,
-			EventID: data.EventID,
+			Timestamp:      data.Timestamp,
+			EventType:      data.EventType,
+			SchemaName:     data.SchemaName,
+			TableName:      data.TableName,
+			BinlogFileNum:  data.BinlogFileNum,
+			BinlogPosition: data.BinlogPosition,
+			Rows:           make([]map[string]interface{}, 1),
+			Gtid:           data.Gtid,
+			Pri:            data.Pri,
+			ColumnMapping:  data.ColumnMapping,
+			EventID:        data.EventID,
 		}
 		newData.Rows[0] = m
-	}else{
+	} else {
 		newData = &pluginDriver.PluginDataType{
-			Timestamp:data.Timestamp,
-			EventType:data.EventType,
-			SchemaName:data.SchemaName,
-			TableName:data.TableName,
-			BinlogFileNum:data.BinlogFileNum,
-			BinlogPosition:data.BinlogPosition,
-			Rows:make([]map[string]interface{},2),
-			Gtid: data.Gtid,
-			Pri: data.Pri,
-			ColumnMapping: data.ColumnMapping,
-			EventID: data.EventID,
+			Timestamp:      data.Timestamp,
+			EventType:      data.EventType,
+			SchemaName:     data.SchemaName,
+			TableName:      data.TableName,
+			BinlogFileNum:  data.BinlogFileNum,
+			BinlogPosition: data.BinlogPosition,
+			Rows:           make([]map[string]interface{}, 2),
+			Gtid:           data.Gtid,
+			Pri:            data.Pri,
+			ColumnMapping:  data.ColumnMapping,
+			EventID:        data.EventID,
 		}
 		m_before := make(map[string]interface{})
 		m_after := make(map[string]interface{})
@@ -545,8 +547,8 @@ func (This *ToServer) filterField(data *pluginDriver.PluginDataType)(newData *pl
 							isNotUpdate = false
 							break
 						}
-						for k,v := range m1{
-							if m2[k] != v{
+						for k, v := range m1 {
+							if m2[k] != v {
 								isNotUpdate = false
 								break
 							}
@@ -562,61 +564,61 @@ func (This *ToServer) filterField(data *pluginDriver.PluginDataType)(newData *pl
 			}
 		}
 		//假如所有字段内容都未变更，并且过滤了这个功能，则直接返回false
-		if isNotUpdate && This.FilterUpdate{
-			return  data,false
+		if isNotUpdate && This.FilterUpdate {
+			return data, false
 		}
 		newData.Rows[0] = m_before
 		newData.Rows[1] = m_after
 	}
-	return newData,true
+	return newData, true
 }
 
 //从插件实例池中获取一个插件实例
-func (This *ToServer) getPluginAndSetParam(MyConsumerId int) (PluginConn *plugin.ToServerConn,err error) {
+func (This *ToServer) getPluginAndSetParam(MyConsumerId int) (PluginConn *plugin.ToServerConn, err error) {
 	PluginConn = plugin.GetPlugin(This.ToServerKey)
-	if PluginConn == nil{
-		return nil,fmt.Errorf("Get Plugin:"+This.PluginName+" ToServerKey:"+ This.ToServerKey+ " err,return nil")
+	if PluginConn == nil {
+		return nil, fmt.Errorf("Get Plugin:" + This.PluginName + " ToServerKey:" + This.ToServerKey + " err,return nil")
 	}
 	This.Lock()
 	defer This.Unlock()
 	if This.cosumerPluginParamArr[MyConsumerId] == nil {
-		This.cosumerPluginParamArr[MyConsumerId],err = PluginConn.GetConn().SetParam(This.PluginParam)
-	}else{
+		This.cosumerPluginParamArr[MyConsumerId], err = PluginConn.GetConn().SetParam(This.PluginParam)
+	} else {
 		_, err = PluginConn.GetConn().SetParam(This.cosumerPluginParamArr[MyConsumerId])
 	}
 	return
 }
 
-func (This *ToServer) timeOutCommit(MyConsumerId int) ( LastSuccessCommitData *pluginDriver.PluginDataType,ErrData *pluginDriver.PluginDataType, err error) {
+func (This *ToServer) timeOutCommit(MyConsumerId int) (LastSuccessCommitData *pluginDriver.PluginDataType, ErrData *pluginDriver.PluginDataType, err error) {
 	defer func() {
-		if err2 := recover();err2 != nil {
-			err = fmt.Errorf("ToServer:%s Commit Debug Err:%s",This.ToServerKey,string(debug.Stack()))
-			log.Println(This.ToServerKey,"sendToServer err:",err)
+		if err2 := recover(); err2 != nil {
+			err = fmt.Errorf("ToServer:%s Commit Debug Err:%s", This.ToServerKey, string(debug.Stack()))
+			log.Println(This.ToServerKey, "sendToServer err:", err)
 		}
 	}()
 
-	PluginConn,err := This.getPluginAndSetParam(MyConsumerId)
+	PluginConn, err := This.getPluginAndSetParam(MyConsumerId)
 	if PluginConn != nil {
 		defer plugin.BackPlugin(PluginConn)
 	}
-	if err != nil{
-		return nil,nil,err
+	if err != nil {
+		return nil, nil, err
 	}
-	LastSuccessCommitData,ErrData, err = PluginConn.GetConn().TimeOutCommit()
+	LastSuccessCommitData, ErrData, err = PluginConn.GetConn().TimeOutCommit()
 	return
 }
 
 /*跳过位点*/
-func (This *ToServer) SkipBinlog(MyConsumerId int,SkipErrData *pluginDriver.PluginDataType) (err error){
+func (This *ToServer) SkipBinlog(MyConsumerId int, SkipErrData *pluginDriver.PluginDataType) (err error) {
 	defer func() {
-		if err2 := recover();err2 != nil {
-			err = fmt.Errorf("ToServer:%s Commit Debug Err:%s",This.ToServerKey,string(debug.Stack()))
-			log.Println(This.ToServerKey,"sendToServer err:",err)
+		if err2 := recover(); err2 != nil {
+			err = fmt.Errorf("ToServer:%s Commit Debug Err:%s", This.ToServerKey, string(debug.Stack()))
+			log.Println(This.ToServerKey, "sendToServer err:", err)
 		}
 	}()
 
-	PluginConn,err := This.getPluginAndSetParam(MyConsumerId)
-	if err != nil{
+	PluginConn, err := This.getPluginAndSetParam(MyConsumerId)
+	if err != nil {
 		return err
 	}
 	defer plugin.BackPlugin(PluginConn)
@@ -624,45 +626,44 @@ func (This *ToServer) SkipBinlog(MyConsumerId int,SkipErrData *pluginDriver.Plug
 	return
 }
 
-
-func (This *ToServer) sendToServer(paramData *pluginDriver.PluginDataType,MyConsumerId int,retry bool) ( lastSuccessCommitData *pluginDriver.PluginDataType,ErrData *pluginDriver.PluginDataType,err error){
+func (This *ToServer) sendToServer(paramData *pluginDriver.PluginDataType, MyConsumerId int, retry bool) (lastSuccessCommitData *pluginDriver.PluginDataType, ErrData *pluginDriver.PluginDataType, err error) {
 	defer func() {
-		if err2 := recover();err2 != nil{
-			err = fmt.Errorf("sendToServer:%s Commit Debug Err:%s",This.ToServerKey,string(debug.Stack()))
-			log.Println(This.ToServerKey,err2,err)
+		if err2 := recover(); err2 != nil {
+			err = fmt.Errorf("sendToServer:%s Commit Debug Err:%s", This.ToServerKey, string(debug.Stack()))
+			log.Println(This.ToServerKey, err2, err)
 		}
 	}()
 
 	// 只有所有字段内容都没有更新，并且开启了过滤功能的情况下，才会返回false
-	data,b := This.filterField(paramData)
+	data, b := This.filterField(paramData)
 	if b == false {
-		return paramData,nil,nil
+		return paramData, nil, nil
 	}
-	PluginConn,err := This.getPluginAndSetParam(MyConsumerId)
-	if err != nil{
-		return lastSuccessCommitData,data,err
+	PluginConn, err := This.getPluginAndSetParam(MyConsumerId)
+	if err != nil {
+		return lastSuccessCommitData, data, err
 	}
 	defer plugin.BackPlugin(PluginConn)
 
 	switch data.EventType {
 	case "insert":
-		lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Insert(data,retry)
+		lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Insert(data, retry)
 		break
 	case "update":
-		lastSuccessCommitData, ErrData ,err = PluginConn.GetConn().Update(data,retry)
+		lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Update(data, retry)
 		break
 	case "delete":
-		lastSuccessCommitData, ErrData ,err = PluginConn.GetConn().Del(data,retry)
+		lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Del(data, retry)
 		break
 	case "sql":
 		if data.Query == "COMMIT" {
-			lastSuccessCommitData, ErrData ,err = PluginConn.GetConn().Commit(data,retry)
-		}else{
-			lastSuccessCommitData, ErrData ,err = PluginConn.GetConn().Query(data,retry)
+			lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Commit(data, retry)
+		} else {
+			lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Query(data, retry)
 		}
 		break
 	case "commit":
-		lastSuccessCommitData, ErrData ,err = PluginConn.GetConn().Commit(data,retry)
+		lastSuccessCommitData, ErrData, err = PluginConn.GetConn().Commit(data, retry)
 		break
 	default:
 		break


### PR DESCRIPTION
#  问题

修复当订阅库中表时，存在表同步不及时的问题。不知道能否算为bug

# 问题说明

![image](https://user-images.githubusercontent.com/7694194/120425420-bf80b900-c3a0-11eb-9a47-ca2acf655c8b.png)

如上图所示，当我们只订阅表a时，同时表b一直会有数据写入，此时，往表a中写入数据不会触发`plugin_commit_timeout=5`这个配置项的条件，只有等到batchsize为1000时才会插入数据到clickhouse中。

# 调试步骤

我们找到了定时器的代码，并加入了日志查看发现，当b表中一直有数据插入时，会进入select的第一个逻辑，然后又把定时器重置(绿色线的逻辑)，这样定时器的逻辑永远得不到执行，只能退化为满足batchsize为1000才会插入数据。

![image](https://user-images.githubusercontent.com/7694194/120425730-4fbefe00-c3a1-11eb-9180-6204738ca521.png)

![image](https://user-images.githubusercontent.com/7694194/120425966-c2c87480-c3a1-11eb-9a8e-c7c96e74d8de.png)

# 解决方法

调整定时器重置的逻辑，但是会存在另外一个问题，因为强制的5s刷一次，所以可能会导致插入ck的性能会较低