### PR TITLE
Add support for int64 and int32 in mysql parser

### DIFF
--- a/Bristol/mysql/parser.go
+++ b/Bristol/mysql/parser.go
@@ -485,6 +485,11 @@ func (parser *eventParser) GetTableSchemaByName(tableId uint64, database string,
 				CHARACTER_OCTET_LENGTH = uint64(dest[9].(uint32))
 			case uint64:
 				CHARACTER_OCTET_LENGTH = dest[9].(uint64)
+			case int64:
+				CHARACTER_OCTET_LENGTH = uint64(dest[9].(int64))
+			case int32:
+				CHARACTER_OCTET_LENGTH = uint64(dest[9].(int32))
+
 			default:
 				CHARACTER_OCTET_LENGTH = 0
 			}


### PR DESCRIPTION
mysql 8.0.34  查询SELECT COLUMN_NAME,COLUMN_KEY,COLUMN_TYPE,CHARACTER_SET_NAME,COLLATION_NAME,NUMERIC_SCALE,EXTRA,COLUMN_DEFAULT,DATA_TYPE,CHARACTER_OCTET_LENGTH,IS_NULLABLE FROM information_schema.columns  返回CHARACTER_OCTET_LENGTH 是int64 ，未能解析导致触发 Bifrost/Bristol/mysql/event_row.go:599 异常