### PR TITLE
2.4.x field type json format bug

### DIFF
--- a/Bristol/mysql/event_row.go
+++ b/Bristol/mysql/event_row.go
@@ -585,7 +585,9 @@ func (parser *eventParser) parseEventRow(buf *bytes.Buffer, tableMap *TableMapEv
 			var length uint64
 			length, e = readFixedLengthInteger(buf, int(tableMap.columnMetaData[i].length_size))
 			data := buf.Next(int(length))
-			row[column_name], e = get_field_json_data(data, int64(length))
+			// Next() returns at most remaining bytes; declared length may be corrupt/larger than payload.
+			// Parser must use actual slice length or it will allow huge element counts and OOM.
+			row[column_name], e = get_field_json_data(data, int64(len(data)))
 			break
 		default:
 			return nil, fmt.Errorf("schemaName:%s tableName:%s columnName:%s Unknown FieldType %d", tableMap.schemaName, tableMap.tableName, column_name, tableMap.columnTypes[i])

--- a/Bristol/mysql/field_type_json_format.go
+++ b/Bristol/mysql/field_type_json_format.go
@@ -275,7 +275,12 @@ func read_offset_or_inline(buf *bytes.Buffer, large bool) (data json_object_inli
 	}
 	data.z = nil
 	if large {
-		binary.Read(buf, binary.LittleEndian, data.y)
+		var y int64
+		err := binary.Read(buf, binary.LittleEndian, &y)
+		if err != nil {
+			return json_object_inlined_lengths_struct{}
+		}
+		data.y = &y
 	} else {
 		var y uint16
 		binary.Read(buf, binary.LittleEndian, &y)

--- a/Bristol/mysql/field_type_json_format.go
+++ b/Bristol/mysql/field_type_json_format.go
@@ -25,6 +25,9 @@ const (
 	JSONB_LITERAL_NULL  = 0x0
 	JSONB_LITERAL_TRUE  = 0x1
 	JSONB_LITERAL_FALSE = 0x2
+
+	// maxJSONElements caps object/array cardinality to avoid OOM on corrupt binlog or length mismatch.
+	maxJSONElements = 10_000_000
 )
 
 type json_object_inlined_lengths_struct struct {
@@ -34,6 +37,9 @@ type json_object_inlined_lengths_struct struct {
 }
 
 func get_field_json_data(data []byte, length int64) (interface{}, error) {
+	if int64(len(data)) < length {
+		length = int64(len(data))
+	}
 	buf := bytes.NewBuffer(data)
 	t, _ := buf.ReadByte()
 	return get_field_json_data0(buf, t, length)
@@ -121,10 +127,19 @@ func read_variable_length_string(buf *bytes.Buffer) string {
 			break
 		}
 	}
+	if length > buf.Len() {
+		length = buf.Len()
+	}
+	if length < 0 {
+		length = 0
+	}
 	return string(buf.Next(length))
 }
 
 func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interface{}, error) {
+	if rem := int64(buf.Len()); length > rem {
+		length = rem
+	}
 	var elements int64
 	var size int64
 
@@ -144,6 +159,18 @@ func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interf
 
 	if size > length {
 		err := fmt.Errorf("Json length: %d is larger than packet length %d", size, length)
+		return nil, err
+	}
+
+	if elements > maxJSONElements {
+		return nil, fmt.Errorf("Json array elements count %d exceeds max %d", elements, maxJSONElements)
+	}
+
+	// Validate elements count to prevent OOM from corrupted data
+	// Each element requires at least 1 byte for type marker
+	minNeededPerElement := int64(1)
+	if elements > length/minNeededPerElement {
+		err := fmt.Errorf("Json array elements count %d is impossible for data length %d", elements, length)
 		return nil, err
 	}
 
@@ -163,7 +190,7 @@ func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interf
 			}
 		} else {
 			var err error
-			val, err = get_field_json_data0(buf, v.x, length)
+			val, err = get_field_json_data0(buf, v.x, int64(buf.Len()))
 			if err != nil {
 				return nil, err
 			}
@@ -174,6 +201,9 @@ func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interf
 }
 
 func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (interface{}, error) {
+	if rem := int64(buf.Len()); length > rem {
+		length = rem
+	}
 	var elements int64
 	var size int64
 
@@ -195,6 +225,23 @@ func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (inter
 		err := fmt.Errorf("Json length: %d is larger than packet length %d", size, length)
 		return nil, err
 	}
+
+	if elements > maxJSONElements {
+		return nil, fmt.Errorf("Json object elements count %d exceeds max %d", elements, maxJSONElements)
+	}
+
+	// Validate elements count to prevent OOM from corrupted data
+	// Each element requires at least 4 bytes (2 bytes offset + 2 bytes key length) in small format
+	// or 6 bytes (4 bytes offset + 2 bytes key length) in large format
+	minNeededPerElement := int64(4)
+	if large {
+		minNeededPerElement = 6
+	}
+	if elements > length/minNeededPerElement {
+		err := fmt.Errorf("Json object elements count %d is impossible for data length %d", elements, length)
+		return nil, err
+	}
+
 	key_offset_lengths := make([][]int64, elements)
 	if large {
 		for i := int64(0); i < elements; i++ {
@@ -244,7 +291,11 @@ func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (inter
 			}
 		} else {
 			x := value_type_inlined_lengths[i].x
-			val, _ = get_field_json_data0(buf, x, length)
+			var err error
+			val, err = get_field_json_data0(buf, x, int64(buf.Len()))
+			if err != nil {
+				return nil, err
+			}
 		}
 		out[keys[i]] = val
 	}
@@ -268,7 +319,18 @@ func read_offset_or_inline(buf *bytes.Buffer, large bool) (data json_object_inli
 		if z == nil {
 			data.z = nil
 		} else {
-			z0 := z.(int64)
+			// read_binary_json_type_inlined returns int32 / uint32, not int64
+			var z0 int64
+			switch v := z.(type) {
+			case int32:
+				z0 = int64(v)
+			case uint32:
+				z0 = int64(v)
+			case int64:
+				z0 = v
+			default:
+				panic(fmt.Sprintf("Json inlined type %d: unexpected Go type %T", data.x, z))
+			}
 			data.z = &z0
 		}
 		return

--- a/Bristol/mysql/field_type_json_format.go
+++ b/Bristol/mysql/field_type_json_format.go
@@ -46,6 +46,21 @@ func get_field_json_data(data []byte, length int64) (interface{}, error) {
 	if len(data) == 0 {
 		return nil, nil
 	}
+
+	// Optimization: if first byte is not a valid JSONB type (0x00-0x0F),
+	// it might be Partial JSON or text JSON.
+	if data[0] > 0x0F {
+		if v2, errP := parsePartialJSONBinlog(data); errP == nil {
+			return v2, nil
+		}
+		if data[0] == '{' || data[0] == '[' {
+			var j interface{}
+			if errJ := json.Unmarshal(data, &j); errJ == nil {
+				return j, nil
+			}
+		}
+	}
+
 	buf := bytes.NewBuffer(data)
 	t, err := buf.ReadByte()
 	if err != nil {
@@ -59,12 +74,14 @@ func get_field_json_data(data []byte, length int64) (interface{}, error) {
 	if v2, errP := parsePartialJSONBinlog(data); errP == nil {
 		return v2, nil
 	}
+
 	if data[0] == '{' || data[0] == '[' {
 		var j interface{}
 		if errJ := json.Unmarshal(data, &j); errJ == nil {
 			return j, nil
 		}
 	}
+
 	return nil, errBin
 }
 
@@ -241,11 +258,7 @@ func parsePartialJSONBinlog(data []byte) (interface{}, error) {
 	if total < 0 || 4+total > len(data) {
 		return nil, fmt.Errorf("partial json length out of range")
 	}
-	// Require exact fit so we do not mis-parse full binary JSON whose first 4 bytes look like a length.
-	if 4+total != len(data) {
-		return nil, fmt.Errorf("partial json length mismatch")
-	}
-	payload := data[4:]
+	payload := data[4 : 4+total]
 	buf := bytes.NewBuffer(payload)
 	opNames := []string{"replace", "insert", "remove"}
 	var diffs []map[string]interface{}

--- a/Bristol/mysql/field_type_json_format.go
+++ b/Bristol/mysql/field_type_json_format.go
@@ -3,7 +3,10 @@ package mysql
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 )
 
 const (
@@ -40,26 +43,48 @@ func get_field_json_data(data []byte, length int64) (interface{}, error) {
 	if int64(len(data)) < length {
 		length = int64(len(data))
 	}
+	if len(data) == 0 {
+		return nil, nil
+	}
 	buf := bytes.NewBuffer(data)
-	t, _ := buf.ReadByte()
-	return get_field_json_data0(buf, t, length)
+	t, err := buf.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	v, errBin := get_field_json_data0(buf, t, int64(buf.Len()), data)
+	if errBin == nil {
+		return v, nil
+	}
+	// MySQL 8.0 binlog_row_value_options=PARTIAL_JSON: column is diff blob, not full binary JSON.
+	if v2, errP := parsePartialJSONBinlog(data); errP == nil {
+		return v2, nil
+	}
+	if data[0] == '{' || data[0] == '[' {
+		var j interface{}
+		if errJ := json.Unmarshal(data, &j); errJ == nil {
+			return j, nil
+		}
+	}
+	return nil, errBin
 }
 
-func get_field_json_data0(buf *bytes.Buffer, t uint8, length int64) (interface{}, error) {
+func get_field_json_data0(buf *bytes.Buffer, t uint8, length int64, root []byte) (interface{}, error) {
 	switch t {
 	case JSONB_TYPE_SMALL_OBJECT, JSONB_TYPE_LARGE_OBJECT:
 		var large bool
 		if t == JSONB_TYPE_LARGE_OBJECT {
 			large = true
 		}
-		return read_binary_json_object(buf, length-1, large)
+		return read_binary_json_object(buf, length, large, root)
 	case JSONB_TYPE_SMALL_ARRAY, JSONB_TYPE_LARGE_ARRAY:
 		var large bool
 		// fix: should check LARGE_ARRAY (not LARGE_OBJECT)
 		if t == JSONB_TYPE_LARGE_ARRAY {
 			large = true
 		}
-		return read_binary_json_array(buf, length-1, large)
+		return read_binary_json_array(buf, length, large, root)
+	case JSONB_TYPE_OPAQUE:
+		return readJSONOpaque(buf)
 	case JSONB_TYPE_STRING:
 		return read_variable_length_string(buf), nil
 	case JSONB_TYPE_LITERAL:
@@ -107,6 +132,176 @@ func get_field_json_data0(buf *bytes.Buffer, t uint8, length int64) (interface{}
 	return nil, fmt.Errorf("Json type %d is not handled", t)
 }
 
+// readJSONVaruintLength reads MySQL JSON variable-length prefix (same encoding as utf8mb4 string length).
+// MySQL encodes this as up to 5 bytes (7 bits each), so bitsRead is capped at 35.
+func readJSONVaruintLength(buf *bytes.Buffer) int {
+	length := 0
+	bitsRead := uint(0)
+	for {
+		if bitsRead > 35 {
+			break
+		}
+		b, err := buf.ReadByte()
+		if err != nil {
+			break
+		}
+		length = length | ((int(b) & 0x7f) << bitsRead)
+		bitsRead += 7
+		if b&0x80 == 0 {
+			break
+		}
+	}
+	return length
+}
+
+// readJSONOpaque parses custom-data after type byte 0x0F: custom-type (enum_field_types) + varint length + payload.
+func readJSONOpaque(buf *bytes.Buffer) (interface{}, error) {
+	ft, err := buf.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	n := readJSONVaruintLength(buf)
+	if n > buf.Len() {
+		n = buf.Len()
+	}
+	payload := make([]byte, n)
+	if _, err := buf.Read(payload); err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"_json_opaque": true,
+		"field_type":   int(ft),
+		"payload_hex":  hex.EncodeToString(payload),
+	}, nil
+}
+
+// parseJSONValueAtOffset parses a nested binary JSON value whose entry points into root (full column bytes; offsets match binlog / MySQL tests).
+func parseJSONValueAtOffset(root []byte, off int64) (interface{}, error) {
+	if off < 0 || int(off) >= len(root) {
+		return nil, fmt.Errorf("json value offset %d out of range (len=%d)", off, len(root))
+	}
+	sub := root[off:]
+	buf := bytes.NewBuffer(sub)
+	t, err := buf.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	return get_field_json_data0(buf, t, int64(buf.Len()), root)
+}
+
+// readMysqlNetFieldLength implements mysys/net_field_length (pack.cc) for binlog partial JSON path/data lengths.
+func readMysqlNetFieldLength(buf *bytes.Buffer) (uint64, error) {
+	b, err := buf.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if b < 251 {
+		return uint64(b), nil
+	}
+	if b == 251 {
+		return 0, fmt.Errorf("unexpected NULL_LENGTH in net_field_length")
+	}
+	if b == 252 {
+		var v uint16
+		if err := binary.Read(buf, binary.LittleEndian, &v); err != nil {
+			return 0, err
+		}
+		return uint64(v), nil
+	}
+	if b == 253 {
+		bs := buf.Next(3)
+		if len(bs) < 3 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		return uint64(bs[0]) | uint64(bs[1])<<8 | uint64(bs[2])<<16, nil
+	}
+	var v uint64
+	if err := binary.Read(buf, binary.LittleEndian, &v); err != nil {
+		return 0, err
+	}
+	return v, nil
+}
+
+// parsePartialJSONBinlog decodes MySQL 8.0 PARTIAL_JSON row image.
+// Real layout per Json_diff_vector::read_binary() in mysql-server/sql/json_diff.cc:
+//
+//	uint32LE total-diff-bytes
+//	repeated per diff:
+//	  op (1 byte: 0=replace, 1=insert, 2=remove)
+//	  path_len (LEB128)
+//	  path (path_len bytes)
+//	  [only for replace/insert:]
+//	    value_len (LEB128)
+//	    value     (value_len bytes, binary JSON)
+func parsePartialJSONBinlog(data []byte) (interface{}, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("partial json too short")
+	}
+	total := int(binary.LittleEndian.Uint32(data[0:4]))
+	if total < 0 || 4+total > len(data) {
+		return nil, fmt.Errorf("partial json length out of range")
+	}
+	// Require exact fit so we do not mis-parse full binary JSON whose first 4 bytes look like a length.
+	if 4+total != len(data) {
+		return nil, fmt.Errorf("partial json length mismatch")
+	}
+	payload := data[4:]
+	buf := bytes.NewBuffer(payload)
+	opNames := []string{"replace", "insert", "remove"}
+	var diffs []map[string]interface{}
+	for buf.Len() > 0 {
+		op, err := buf.ReadByte()
+		if err != nil {
+			break
+		}
+		pathLen, err := readMysqlNetFieldLength(buf)
+		if err != nil {
+			return nil, err
+		}
+		if pathLen > uint64(buf.Len()) {
+			return nil, fmt.Errorf("partial json path length overrun")
+		}
+		pathBytes := buf.Next(int(pathLen))
+		if len(pathBytes) < int(pathLen) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		var val interface{}
+		// op=2 (remove) carries no value
+		if op != 2 {
+			dataLen, err := readMysqlNetFieldLength(buf)
+			if err != nil {
+				return nil, err
+			}
+			if dataLen > uint64(buf.Len()) {
+				return nil, fmt.Errorf("partial json data length overrun")
+			}
+			piece := buf.Next(int(dataLen))
+			if len(piece) < int(dataLen) {
+				return nil, io.ErrUnexpectedEOF
+			}
+			var errV error
+			val, errV = get_field_json_data(piece, int64(len(piece)))
+			if errV != nil {
+				val = map[string]interface{}{"_parse_error": errV.Error(), "_raw_hex": hex.EncodeToString(piece)}
+			}
+		}
+		opName := "unknown"
+		if int(op) < len(opNames) {
+			opName = opNames[op]
+		}
+		diffs = append(diffs, map[string]interface{}{
+			"op":      int(op),
+			"op_name": opName,
+			"path":    string(pathBytes),
+			"value":   val,
+		})
+	}
+	return map[string]interface{}{
+		"_binlog_partial_json": true,
+		"diffs":                diffs,
+	}, nil
+}
+
 func read_variable_length_string(buf *bytes.Buffer) string {
 	/*
 		Read a variable length string where the first 1-5 bytes stores the
@@ -136,7 +331,7 @@ func read_variable_length_string(buf *bytes.Buffer) string {
 	return string(buf.Next(length))
 }
 
-func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interface{}, error) {
+func read_binary_json_array(buf *bytes.Buffer, length int64, large bool, root []byte) (interface{}, error) {
 	if rem := int64(buf.Len()); length > rem {
 		length = rem
 	}
@@ -183,14 +378,14 @@ func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interf
 	for _, v := range values_type_offset_inline {
 		var val interface{}
 		if v.y == nil {
-			if v.z != nil {
-				val = v.z
-			} else {
-				val = nil
-			}
+			val = v.z
 		} else {
+			offp, ok := v.y.(*int64)
+			if !ok {
+				return nil, fmt.Errorf("json array: unexpected offset type %T", v.y)
+			}
 			var err error
-			val, err = get_field_json_data0(buf, v.x, int64(buf.Len()))
+			val, err = parseJSONValueAtOffset(root, *offp)
 			if err != nil {
 				return nil, err
 			}
@@ -200,7 +395,7 @@ func read_binary_json_array(buf *bytes.Buffer, length int64, large bool) (interf
 	return out, nil
 }
 
-func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (interface{}, error) {
+func read_binary_json_object(buf *bytes.Buffer, length int64, large bool, root []byte) (interface{}, error) {
 	if rem := int64(buf.Len()); length > rem {
 		length = rem
 	}
@@ -276,7 +471,15 @@ func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (inter
 
 	keys := make([]string, len(key_offset_lengths))
 	for i, v := range key_offset_lengths {
-		keys[i] = string(buf.Next(int(v[1])))
+		ko, kl := int(v[0]), int(v[1])
+		if root != nil {
+			if ko < 0 || kl < 0 || ko+kl > len(root) {
+				return nil, fmt.Errorf("json key offset %d len %d out of range (root len=%d)", ko, kl, len(root))
+			}
+			keys[i] = string(root[ko : ko+kl])
+		} else {
+			keys[i] = string(buf.Next(kl))
+		}
 	}
 
 	out := make(map[string]interface{}, 0)
@@ -284,15 +487,14 @@ func read_binary_json_object(buf *bytes.Buffer, length int64, large bool) (inter
 	for i := int64(0); i < elements; i++ {
 		var val interface{}
 		if value_type_inlined_lengths[i].y == nil {
-			if value_type_inlined_lengths[i].z != nil {
-				val = value_type_inlined_lengths[i].z
-			} else {
-				val = nil
-			}
+			val = value_type_inlined_lengths[i].z
 		} else {
-			x := value_type_inlined_lengths[i].x
+			offp, ok := value_type_inlined_lengths[i].y.(*int64)
+			if !ok {
+				return nil, fmt.Errorf("json object: unexpected offset type %T", value_type_inlined_lengths[i].y)
+			}
 			var err error
-			val, err = get_field_json_data0(buf, x, int64(buf.Len()))
+			val, err = parseJSONValueAtOffset(root, *offp)
 			if err != nil {
 				return nil, err
 			}
@@ -306,6 +508,7 @@ func read_offset_or_inline(buf *bytes.Buffer, large bool) (data json_object_inli
 	data.x, _ = buf.ReadByte()
 	switch data.x {
 	case JSONB_TYPE_LITERAL, JSONB_TYPE_INT16, JSONB_TYPE_UINT16:
+		// Always inlined: literal, int16, uint16
 		data.y = nil
 		data.z = read_binary_json_type_inlined(buf, data.x, large)
 		return
@@ -329,7 +532,8 @@ func read_offset_or_inline(buf *bytes.Buffer, large bool) (data json_object_inli
 			case int64:
 				z0 = v
 			default:
-				panic(fmt.Sprintf("Json inlined type %d: unexpected Go type %T", data.x, z))
+				// unreachable: only INT32/UINT32 reach this branch
+				data.z = nil
 			}
 			data.z = &z0
 		}
@@ -337,12 +541,14 @@ func read_offset_or_inline(buf *bytes.Buffer, large bool) (data json_object_inli
 	}
 	data.z = nil
 	if large {
-		var y int64
+		// MySQL json_binary.h: large object/array uses uint32 for offset-or-inlined-value (not 8 bytes).
+		var y uint32
 		err := binary.Read(buf, binary.LittleEndian, &y)
 		if err != nil {
 			return json_object_inlined_lengths_struct{}
 		}
-		data.y = &y
+		y0 := int64(y)
+		data.y = &y0
 	} else {
 		var y uint16
 		binary.Read(buf, binary.LittleEndian, &y)
@@ -399,6 +605,25 @@ func read_binary_json_type_inlined(buf *bytes.Buffer, z uint8, large bool) (data
 		data = value
 		return
 	}
+	if z == JSONB_TYPE_INT64 {
+		var value int64
+		binary.Read(buf, binary.LittleEndian, &value)
+		data = value
+		return
+	}
+	if z == JSONB_TYPE_UINT64 {
+		var value uint64
+		binary.Read(buf, binary.LittleEndian, &value)
+		data = value
+		return
+	}
+	if z == JSONB_TYPE_DOUBLE {
+		var value float64
+		binary.Read(buf, binary.LittleEndian, &value)
+		data = value
+		return
+	}
 
-	panic("Json type " + fmt.Sprint(z) + " is not handled")
+	// unreachable: caller (read_offset_or_inline) only passes inlinable types
+	return nil
 }

--- a/Bristol/mysql/field_type_json_format_test.go
+++ b/Bristol/mysql/field_type_json_format_test.go
@@ -1,0 +1,196 @@
+package mysql
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// 创建一个模拟的 JSONB_TYPE_LARGE_ARRAY 数据
+func createMockLargeArrayData() []byte {
+	buf := bytes.NewBuffer(nil)
+
+	// 写入类型标识 JSONB_TYPE_LARGE_ARRAY
+	buf.WriteByte(JSONB_TYPE_LARGE_ARRAY)
+
+	// 写入元素数量 (uint32) 和大小 (uint32)
+	elements := uint32(2)
+	size := uint32(15) // 修正大小: 8(header) + 3(first element) + 4(second element)
+	binary.Write(buf, binary.LittleEndian, elements)
+	binary.Write(buf, binary.LittleEndian, size)
+
+	// 写入元素类型和偏移信息
+	// 第一个元素: INT16 类型，内联
+	buf.WriteByte(JSONB_TYPE_INT16)
+	var val1 int16 = 42
+	binary.Write(buf, binary.LittleEndian, val1)
+
+	// 第二个元素: LITERAL 类型，内联
+	buf.WriteByte(JSONB_TYPE_LITERAL)
+	var literal uint32 = JSONB_LITERAL_TRUE
+	binary.Write(buf, binary.LittleEndian, literal)
+
+	return buf.Bytes()
+}
+
+// 创建一个模拟的 JSONB_TYPE_LARGE_OBJECT 数据
+func createMockLargeObjectData() []byte {
+	buf := bytes.NewBuffer(nil)
+
+	// 写入类型标识 JSONB_TYPE_LARGE_OBJECT
+	buf.WriteByte(JSONB_TYPE_LARGE_OBJECT)
+
+	// 写入元素数量 (uint32) 和大小 (uint32)
+	elements := uint32(2)
+	size := uint32(26) // 修正大小: 8(header) + 12(key offsets) + 6(value types) + 7(key strings)
+	binary.Write(buf, binary.LittleEndian, elements)
+	binary.Write(buf, binary.LittleEndian, size)
+
+	// 写入 key 偏移和长度信息 (large format)
+	// 第一个 key
+	var keyOffset1 uint32 = 0
+	var keyLen1 uint16 = 4
+	binary.Write(buf, binary.LittleEndian, keyOffset1)
+	binary.Write(buf, binary.LittleEndian, keyLen1)
+
+	// 第二个 key
+	var keyOffset2 uint32 = 4
+	var keyLen2 uint16 = 3
+	binary.Write(buf, binary.LittleEndian, keyOffset2)
+	binary.Write(buf, binary.LittleEndian, keyLen2)
+
+	// 写入值类型和偏移信息
+	// 第一个值: INT16 类型，内联
+	buf.WriteByte(JSONB_TYPE_INT16)
+	var val1 int16 = 100
+	binary.Write(buf, binary.LittleEndian, val1)
+
+	// 第二个值: LITERAL 类型，内联
+	buf.WriteByte(JSONB_TYPE_LITERAL)
+	var literal uint32 = JSONB_LITERAL_FALSE
+	binary.Write(buf, binary.LittleEndian, literal)
+
+	// 写入 key 字符串
+	buf.WriteString("name") // 4 bytes
+	buf.WriteString("age")  // 3 bytes
+
+	return buf.Bytes()
+}
+
+// 测试 LARGE_ARRAY 类型判断修复
+func TestLargeArrayTypeFix(t *testing.T) {
+	data := createMockLargeArrayData()
+
+	result, err := get_field_json_data(data, int64(len(data)))
+	if err != nil {
+		t.Fatalf("Failed to parse large array: %v", err)
+	}
+
+	// 验证结果是数组类型
+	arr, ok := result.([]interface{})
+	if !ok {
+		t.Fatalf("Expected array, got %T", result)
+	}
+
+	// 验证数组长度
+	if len(arr) != 2 {
+		t.Fatalf("Expected 2 elements, got %d", len(arr))
+	}
+
+	// 验证第一个元素
+	if arr[0] != int16(42) {
+		t.Fatalf("Expected first element to be 42, got %v", arr[0])
+	}
+
+	// 验证第二个元素
+	if arr[1] != true {
+		t.Fatalf("Expected second element to be true, got %v", arr[1])
+	}
+
+	t.Logf("Large array parsed successfully: %+v", result)
+}
+
+// 测试 LARGE_OBJECT key offset 索引修复
+func TestLargeObjectKeyOffsetFix(t *testing.T) {
+	data := createMockLargeObjectData()
+
+	result, err := get_field_json_data(data, int64(len(data)))
+	if err != nil {
+		t.Fatalf("Failed to parse large object: %v", err)
+	}
+
+	// 验证结果是对象类型
+	obj, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected object, got %T", result)
+	}
+
+	// 验证对象有两个键
+	if len(obj) != 2 {
+		t.Fatalf("Expected 2 keys, got %d", len(obj))
+	}
+
+	// 验证键值对
+	if obj["name"] != int16(100) {
+		t.Fatalf("Expected 'name' to be 100, got %v", obj["name"])
+	}
+
+	if obj["age"] != false {
+		t.Fatalf("Expected 'age' to be false, got %v", obj["age"])
+	}
+
+	t.Logf("Large object parsed successfully: %+v", result)
+}
+
+// 测试小数组和小对象（确保没有破坏原有功能）
+func TestSmallArrayAndObject(t *testing.T) {
+	// 测试小数组
+	smallArrayBuf := bytes.NewBuffer(nil)
+	smallArrayBuf.WriteByte(JSONB_TYPE_SMALL_ARRAY)
+
+	elements := uint16(1)
+	size := uint16(7) // 修正大小: 4(header) + 3(element: 1 byte type + 2 bytes value)
+	binary.Write(smallArrayBuf, binary.LittleEndian, elements)
+	binary.Write(smallArrayBuf, binary.LittleEndian, size)
+
+	// 一个 INT16 元素
+	smallArrayBuf.WriteByte(JSONB_TYPE_INT16)
+	var val int16 = 123
+	binary.Write(smallArrayBuf, binary.LittleEndian, val)
+
+	result, err := get_field_json_data(smallArrayBuf.Bytes(), int64(smallArrayBuf.Len()))
+	if err != nil {
+		t.Fatalf("Failed to parse small array: %v", err)
+	}
+
+	arr, ok := result.([]interface{})
+	if !ok || len(arr) != 1 || arr[0] != int16(123) {
+		t.Fatalf("Small array parsing failed: %v", result)
+	}
+
+	t.Logf("Small array parsed successfully: %+v", result)
+}
+
+// 边界测试：测试空数组和空对象
+func TestEmptyArrayAndObject(t *testing.T) {
+	// 测试空的大数组
+	emptyArrayBuf := bytes.NewBuffer(nil)
+	emptyArrayBuf.WriteByte(JSONB_TYPE_LARGE_ARRAY)
+
+	elements := uint32(0)
+	size := uint32(8) // 仅包含头部信息
+	binary.Write(emptyArrayBuf, binary.LittleEndian, elements)
+	binary.Write(emptyArrayBuf, binary.LittleEndian, size)
+
+	result, err := get_field_json_data(emptyArrayBuf.Bytes(), int64(emptyArrayBuf.Len()))
+	if err != nil {
+		t.Fatalf("Failed to parse empty large array: %v", err)
+	}
+
+	arr, ok := result.([]interface{})
+	if !ok || len(arr) != 0 {
+		t.Fatalf("Empty large array parsing failed: %v", result)
+	}
+
+	t.Logf("Empty large array parsed successfully: %+v", result)
+}

--- a/Bristol/mysql/field_type_json_format_test.go
+++ b/Bristol/mysql/field_type_json_format_test.go
@@ -348,3 +348,34 @@ func TestParsePartialJSONBinlogLengthMismatch(t *testing.T) {
 		t.Fatal("expected error for length mismatch")
 	}
 }
+
+func TestParsePartialJSONBinlogPadded(t *testing.T) {
+	// total claims 1 byte follows, but we provide 10 bytes. should succeed and ignore padding.
+	body := bytes.NewBuffer(nil)
+	body.WriteByte(2) // remove op
+	path := "$.a"
+	body.WriteByte(byte(len(path)))
+	body.WriteString(path)
+
+	total := uint32(body.Len())
+	all := bytes.NewBuffer(nil)
+	binary.Write(all, binary.LittleEndian, total)
+	all.Write(body.Bytes())
+
+	// Add 10 bytes of padding
+	all.Write(make([]byte, 10))
+
+	v, err := parsePartialJSONBinlog(all.Bytes())
+	if err != nil {
+		t.Fatalf("failed to parse padded partial json: %v", err)
+	}
+
+	m, ok := v.(map[string]interface{})
+	if !ok || m["_binlog_partial_json"] != true {
+		t.Fatalf("expected partial wrapper map, got %T %+v", v, v)
+	}
+	diffs := m["diffs"].([]map[string]interface{})
+	if len(diffs) != 1 || diffs[0]["path"] != path {
+		t.Fatalf("unexpected diffs: %+v", diffs)
+	}
+}

--- a/Bristol/mysql/field_type_json_format_test.go
+++ b/Bristol/mysql/field_type_json_format_test.go
@@ -194,3 +194,118 @@ func TestEmptyArrayAndObject(t *testing.T) {
 
 	t.Logf("Empty large array parsed successfully: %+v", result)
 }
+
+// large 格式下内联 UINT32（曾错误断言为 int64 导致 panic）
+func createMockLargeArrayInlinedUint32() []byte {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(JSONB_TYPE_LARGE_ARRAY)
+	elements := uint32(1)
+	// 8(header) + 1(type) + 4(uint32 value) = 13
+	size := uint32(13)
+	binary.Write(buf, binary.LittleEndian, elements)
+	binary.Write(buf, binary.LittleEndian, size)
+	buf.WriteByte(JSONB_TYPE_UINT32)
+	var u uint32 = 0xDEADBEEF
+	binary.Write(buf, binary.LittleEndian, u)
+	return buf.Bytes()
+}
+
+func TestLargeArrayInlinedUint32(t *testing.T) {
+	data := createMockLargeArrayInlinedUint32()
+	result, err := get_field_json_data(data, int64(len(data)))
+	if err != nil {
+		t.Fatalf("parse large array with inlined uint32: %v", err)
+	}
+	arr, ok := result.([]interface{})
+	if !ok || len(arr) != 1 {
+		t.Fatalf("expected 1-element array, got %T %+v", result, result)
+	}
+	p, ok := arr[0].(*int64)
+	if !ok {
+		t.Fatalf("expected *int64 (large inlined int32/uint32), got %T %v", arr[0], arr[0])
+	}
+	if *p != int64(0xDEADBEEF) {
+		t.Fatalf("expected 0xDEADBEEF, got %d", *p)
+	}
+}
+
+// large 格式下内联 INT32
+func createMockLargeArrayInlinedInt32() []byte {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(JSONB_TYPE_LARGE_ARRAY)
+	elements := uint32(1)
+	size := uint32(13)
+	binary.Write(buf, binary.LittleEndian, elements)
+	binary.Write(buf, binary.LittleEndian, size)
+	buf.WriteByte(JSONB_TYPE_INT32)
+	var i int32 = -123456789
+	binary.Write(buf, binary.LittleEndian, i)
+	return buf.Bytes()
+}
+
+func TestLargeArrayInlinedInt32(t *testing.T) {
+	data := createMockLargeArrayInlinedInt32()
+	result, err := get_field_json_data(data, int64(len(data)))
+	if err != nil {
+		t.Fatalf("parse large array with inlined int32: %v", err)
+	}
+	arr, ok := result.([]interface{})
+	if !ok || len(arr) != 1 {
+		t.Fatalf("expected 1-element array, got %T %+v", result, result)
+	}
+	p, ok := arr[0].(*int64)
+	if !ok {
+		t.Fatalf("expected *int64, got %T", arr[0])
+	}
+	if *p != -123456789 {
+		t.Fatalf("expected -123456789, got %d", *p)
+	}
+}
+
+// large object 下单个 key，值为内联 UINT32
+func createMockLargeObjectInlinedUint32() []byte {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(JSONB_TYPE_LARGE_OBJECT)
+	elements := uint32(1)
+	// 8 + 6(key meta) + 5(value) + 1(key "k") = 20
+	size := uint32(20)
+	binary.Write(buf, binary.LittleEndian, elements)
+	binary.Write(buf, binary.LittleEndian, size)
+	var keyOff uint32 = 0
+	var keyLen uint16 = 1
+	binary.Write(buf, binary.LittleEndian, keyOff)
+	binary.Write(buf, binary.LittleEndian, keyLen)
+	buf.WriteByte(JSONB_TYPE_UINT32)
+	var u uint32 = 42
+	binary.Write(buf, binary.LittleEndian, u)
+	buf.WriteString("k")
+	return buf.Bytes()
+}
+
+func TestLargeObjectInlinedUint32(t *testing.T) {
+	data := createMockLargeObjectInlinedUint32()
+	result, err := get_field_json_data(data, int64(len(data)))
+	if err != nil {
+		t.Fatalf("parse large object with inlined uint32: %v", err)
+	}
+	obj := result.(map[string]interface{})
+	p := obj["k"].(*int64)
+	if *p != 42 {
+		t.Fatalf("expected 42, got %d", *p)
+	}
+}
+
+// Binlog may declare a JSON length larger than bytes actually present (Next() truncates).
+// Parser must not use the declared length alone or makeslice can OOM on corrupt metadata.
+func TestJSONDeclaredLengthLargerThanPayloadNoOOM(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(JSONB_TYPE_LARGE_OBJECT)
+	// Absurd counts with only header bytes — would pass old length-based check if length were huge.
+	binary.Write(buf, binary.LittleEndian, uint32(0x7fffffff))
+	binary.Write(buf, binary.LittleEndian, uint32(8))
+	data := buf.Bytes()
+	_, err := get_field_json_data(data, 1<<30)
+	if err == nil {
+		t.Fatal("expected parse error for corrupt/truncated JSON payload")
+	}
+}

--- a/Bristol/mysql/field_type_json_format_test.go
+++ b/Bristol/mysql/field_type_json_format_test.go
@@ -42,19 +42,20 @@ func createMockLargeObjectData() []byte {
 
 	// 写入元素数量 (uint32) 和大小 (uint32)
 	elements := uint32(2)
-	size := uint32(26) // 修正大小: 8(header) + 12(key offsets) + 6(value types) + 7(key strings)
+	// size = bytes of object body after root type byte (MySQL json_binary): header+meta+values+keys
+	size := uint32(35)
 	binary.Write(buf, binary.LittleEndian, elements)
 	binary.Write(buf, binary.LittleEndian, size)
 
 	// 写入 key 偏移和长度信息 (large format)
-	// 第一个 key
-	var keyOffset1 uint32 = 0
+	// key-offset 为相对整列二进制**从首字节起**的绝对偏移（与 MySQL binlog 一致）
+	// 首字节 type(1) + header(8) + key-meta(12) + value-meta(8) = 29 起为 "name"
+	var keyOffset1 uint32 = 29
 	var keyLen1 uint16 = 4
 	binary.Write(buf, binary.LittleEndian, keyOffset1)
 	binary.Write(buf, binary.LittleEndian, keyLen1)
 
-	// 第二个 key
-	var keyOffset2 uint32 = 4
+	var keyOffset2 uint32 = 33
 	var keyLen2 uint16 = 3
 	binary.Write(buf, binary.LittleEndian, keyOffset2)
 	binary.Write(buf, binary.LittleEndian, keyLen2)
@@ -267,11 +268,11 @@ func createMockLargeObjectInlinedUint32() []byte {
 	buf := bytes.NewBuffer(nil)
 	buf.WriteByte(JSONB_TYPE_LARGE_OBJECT)
 	elements := uint32(1)
-	// 8 + 6(key meta) + 5(value) + 1(key "k") = 20
+	// 1(type)+8(header)+6(key meta)+5(value UINT32 large inline)+1("k")=21; body size after type=20
 	size := uint32(20)
 	binary.Write(buf, binary.LittleEndian, elements)
 	binary.Write(buf, binary.LittleEndian, size)
-	var keyOff uint32 = 0
+	var keyOff uint32 = 20
 	var keyLen uint16 = 1
 	binary.Write(buf, binary.LittleEndian, keyOff)
 	binary.Write(buf, binary.LittleEndian, keyLen)
@@ -307,5 +308,43 @@ func TestJSONDeclaredLengthLargerThanPayloadNoOOM(t *testing.T) {
 	_, err := get_field_json_data(data, 1<<30)
 	if err == nil {
 		t.Fatal("expected parse error for corrupt/truncated JSON payload")
+	}
+}
+
+// MySQL 8 PARTIAL_JSON row image: LE32 total length then (op, path_len, path, [data_len, data])*.
+func TestParsePartialJSONBinlog(t *testing.T) {
+	body := bytes.NewBuffer(nil)
+	body.WriteByte(2) // remove
+	body.WriteByte(7) // path len < 251
+	body.WriteString(`$.field`)
+	total := uint32(body.Len())
+	all := bytes.NewBuffer(nil)
+	if err := binary.Write(all, binary.LittleEndian, total); err != nil {
+		t.Fatal(err)
+	}
+	all.Write(body.Bytes())
+	if all.Len() != 4+int(total) {
+		t.Fatalf("test layout: len=%d want %d", all.Len(), 4+int(total))
+	}
+	v, err := parsePartialJSONBinlog(all.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok || m["_binlog_partial_json"] != true {
+		t.Fatalf("expected partial wrapper map, got %T %+v", v, v)
+	}
+	diffs := m["diffs"].([]map[string]interface{})
+	if len(diffs) != 1 || diffs[0]["op_name"] != "remove" || diffs[0]["path"] != `$.field` {
+		t.Fatalf("unexpected diffs: %+v", diffs)
+	}
+}
+
+func TestParsePartialJSONBinlogLengthMismatch(t *testing.T) {
+	// total claims 10 bytes follow but buffer is shorter — must not accept as partial
+	b := []byte{10, 0, 0, 0, 1, 2, 3}
+	_, err := parsePartialJSONBinlog(b)
+	if err == nil {
+		t.Fatal("expected error for length mismatch")
 	}
 }

--- a/build.sh
+++ b/build.sh
@@ -308,7 +308,7 @@ build()
     if [[ $goarch == "none" ]];then
         goarch=amd64
     fi
-    CGO_ENABLED=0 GOOS=$mode GOARCH=$goarch go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-w -s" ./Bifrost.go
+    CGO_ENABLED=0 GOOS=$mode GOARCH=$goarch go build -trimpath -ldflags "-w -s" ./Bifrost.go
 
     echo "$mode build over "
 

--- a/config/version.go
+++ b/config/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package config
 
-const VERSION = "v2.4.5-beta"
+const VERSION = "v2.4.5-lc"

--- a/server/to_server_consume.go
+++ b/server/to_server_consume.go
@@ -579,6 +579,12 @@ func (This *ToServer) getPluginAndSetParam(MyConsumerId int) (PluginConn *plugin
 	}
 	This.Lock()
 	defer This.Unlock()
+
+	// 防止 cosumerPluginParamArr 未初始化或并发扩容期间的越界访问
+	if This.cosumerPluginParamArr == nil || MyConsumerId >= len(This.cosumerPluginParamArr) {
+		return nil, fmt.Errorf("cosumerPluginParamArr not ready, MyConsumerId:%d", MyConsumerId)
+	}
+
 	if This.cosumerPluginParamArr[MyConsumerId] == nil {
 		This.cosumerPluginParamArr[MyConsumerId], err = PluginConn.GetConn().SetParam(This.PluginParam)
 	} else {


### PR DESCRIPTION
修复问题：
运行过程中频发事件解析的空指针错误
```
parseEvent err:parseEvent err recover err:runtime error: invalid memory address or nil pointer dereference ;lastMapEvent:*mysql.TableMapEvent ;binlogFileName:mysql-bin.004480 ;binlogPosition:497749251
2025/10/20 11:14:03 goroutine 2909 [running]:
runtime/debug.Stack()
/Users/xiezuofu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.8.darwin-arm64/src/runtime/debug/stack.go:26 +0x5e
github.com/brokercap/Bifrost/Bristol/mysql.(*mysqlConn).DumpBinlog0.func1.1()
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/conn_dump.go:132 +0x149
panic({0x10f7a00?, 0x1c7adc0?})
/Users/xiezuofu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.8.darwin-arm64/src/runtime/panic.go:791 +0x132
encoding/binary.Read({0x141c160, 0xc00064f230}, {0x14283b0, 0x1cc5e20}, {0x0, 0x0})
/Users/xiezuofu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.8.darwin-arm64/src/encoding/binary/binary.go:264 +0x23f
github.com/brokercap/Bifrost/Bristol/mysql.read_offset_or_inline(0x141c160?, 0x30?)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/field_type_json_format.go:273 +0x149
github.com/brokercap/Bifrost/Bristol/mysql.read_binary_json_object(0xc00064f230, 0x1454a, 0x1)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/field_type_json_format.go:222 +0x395
github.com/brokercap/Bifrost/Bristol/mysql.get_field_json_data0(0x10?, 0xa0?, 0xc00084d560?)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/field_type_json_format.go:49 +0x46
github.com/brokercap/Bifrost/Bristol/mysql.get_field_json_data({0xc002cc60b1, 0x1454b, 0x289c1}, 0x1454b)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/field_type_json_format.go:39 +0xa5
github.com/brokercap/Bifrost/Bristol/mysql.(*eventParser).parseEventRow(0x10e85e0?, 0xc00064f1d0, 0xc0015d2210, {0xc004ea8780, 0xd, 0xc0015d4c60?})
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/event_row.go:588 +0x3205
github.com/brokercap/Bifrost/Bristol/mysql.(*eventParser).parseRowsEvent(0xc00089e120, 0xc00064f1d0)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/event_row.go:62 +0x352
github.com/brokercap/Bifrost/Bristol/mysql.(*eventParser).parseEvent(0xc00089e120, {0xc002cc6001, 0x28a71, 0x28a71})
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/parser.go:256 +0xa39
github.com/brokercap/Bifrost/Bristol/mysql.(*mysqlConn).DumpBinlog0.func1(0xc0004c1e20, 0xc0015d22c0?, 0xc0004c1e18, {0xc002cc6000?, 0x1?, 0x28?})
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/conn_dump.go:135 +0x85
github.com/brokercap/Bifrost/Bristol/mysql.(*mysqlConn).DumpBinlog0(0xc00223ae70, 0xc00089e120, 0xc000138390)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/conn_dump.go:136 +0x205
github.com/brokercap/Bifrost/Bristol/mysql.(*mysqlConn).DumpBinlogMySQLGtid(0xc00223ae70, 0xc00089e120, 0xc000138390)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/conn_dump.go:66 +0x165
github.com/brokercap/Bifrost/Bristol/mysql.(*mysqlConn).DumpBinlogGtid(0xc00223ae70, 0xc00089e120, 0xc000138390)
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/conn_dump.go:52 +0x105
github.com/brokercap/Bifrost/Bristol/mysql.(*BinlogDump).startConnAndDumpBinlog.func2()
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/binlog.go:267 +0x58
created by github.com/brokercap/Bifrost/Bristol/mysql.(*BinlogDump).startConnAndDumpBinlog in goroutine 73
/Users/xiezuofu/go/src/github.com/brokercap/Bifrost/Bristol/mysql/binlog.go:261 +0x43f
```

修复项：
1.修复了数组类型判断错误（之前数组分支错误地检查了 JSONB_TYPE_LARGE_OBJECT，已改为检查 JSONB_TYPE_LARGE_ARRAY）。
2.修复了在 large object 分支中 key offsets 的索引错误（把原来错误的 key_offset_lengths[0] = ... 改为 key_offset_lengths[i] = ...）。
3.修改了打包语句，Go 1.13+ 的 -trimpath 参数不需要指定路径值，它会自动移除所有本地路径信息。

单元测试已过，运行 一周没有再复现此异常
