### PR TITLE
feat: 支持 filter 插件动态字段过滤 (#220)

### DIFF
--- a/plugin/driver/driver_interface.go
+++ b/plugin/driver/driver_interface.go
@@ -62,3 +62,9 @@ func (c *PluginDriverInterface) TimeOutCommit() (LastSuccessCommitData *PluginDa
 func (c *PluginDriverInterface) Skip(SkipData *PluginDataType) error {
 	return nil
 }
+
+// Filter 是可选过滤钩子，插件可按需实现字段动态增删等逻辑。
+// keep=false 表示过滤掉当前事件；keep=true 且返回非nil data 表示继续同步。
+func (c *PluginDriverInterface) Filter(data *PluginDataType, retry bool) (newData *PluginDataType, keep bool, err error) {
+	return data, true, nil
+}

--- a/plugin/driver/filter_interface.go
+++ b/plugin/driver/filter_interface.go
@@ -1,0 +1,9 @@
+package driver
+
+// FilterPluginDriver 是可选接口。
+// 插件实现后可在写入目标端前对事件做动态字段增删、改写或过滤。
+type FilterPluginDriver interface {
+	// keep=false 表示忽略当前事件；keep=true 表示继续同步。
+	// 当 keep=true 时，newData 不能为空。
+	Filter(data *PluginDataType, retry bool) (newData *PluginDataType, keep bool, err error)
+}

--- a/server/to_server_consume.go
+++ b/server/to_server_consume.go
@@ -589,6 +589,27 @@ func (This *ToServer) getPluginAndSetParam(MyConsumerId int) (PluginConn *plugin
 	return
 }
 
+func (This *ToServer) applyPluginFilter(conn pluginDriver.Driver, data *pluginDriver.PluginDataType, retry bool) (newData *pluginDriver.PluginDataType, keep bool, err error) {
+	if data == nil {
+		return data, true, nil
+	}
+	filterPlugin, ok := conn.(pluginDriver.FilterPluginDriver)
+	if !ok {
+		return data, true, nil
+	}
+	newData, keep, err = filterPlugin.Filter(data, retry)
+	if err != nil {
+		return data, keep, err
+	}
+	if keep == false {
+		return data, false, nil
+	}
+	if newData == nil {
+		return data, false, fmt.Errorf("filter plugin return nil data while keep=true")
+	}
+	return newData, true, nil
+}
+
 func (This *ToServer) timeOutCommit(MyConsumerId int) (LastSuccessCommitData *pluginDriver.PluginDataType, ErrData *pluginDriver.PluginDataType, err error) {
 	defer func() {
 		if err2 := recover(); err2 != nil {
@@ -644,6 +665,13 @@ func (This *ToServer) sendToServer(paramData *pluginDriver.PluginDataType, MyCon
 		return lastSuccessCommitData, data, err
 	}
 	defer plugin.BackPlugin(PluginConn)
+	data, b, err = This.applyPluginFilter(PluginConn.GetConn(), data, retry)
+	if err != nil {
+		return lastSuccessCommitData, data, err
+	}
+	if b == false {
+		return paramData, nil, nil
+	}
 
 	switch data.EventType {
 	case "insert":

--- a/server/to_server_consume_filter_test.go
+++ b/server/to_server_consume_filter_test.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"errors"
+	pluginDriver "github.com/brokercap/Bifrost/plugin/driver"
+	"testing"
+)
+
+type mockBasePluginDriver struct{}
+
+func (m *mockBasePluginDriver) SetOption(uri *string, param map[string]interface{}) {}
+
+func (m *mockBasePluginDriver) Open() error {
+	return nil
+}
+
+func (m *mockBasePluginDriver) Close() bool {
+	return true
+}
+
+func (m *mockBasePluginDriver) GetUriExample() string {
+	return ""
+}
+
+func (m *mockBasePluginDriver) CheckUri() error {
+	return nil
+}
+
+func (m *mockBasePluginDriver) Insert(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return data, nil, nil
+}
+
+func (m *mockBasePluginDriver) Update(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return data, nil, nil
+}
+
+func (m *mockBasePluginDriver) Del(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return data, nil, nil
+}
+
+func (m *mockBasePluginDriver) Query(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return data, nil, nil
+}
+
+func (m *mockBasePluginDriver) Commit(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return data, nil, nil
+}
+
+func (m *mockBasePluginDriver) SetParam(p interface{}) (interface{}, error) {
+	return p, nil
+}
+
+func (m *mockBasePluginDriver) TimeOutCommit() (*pluginDriver.PluginDataType, *pluginDriver.PluginDataType, error) {
+	return nil, nil, nil
+}
+
+func (m *mockBasePluginDriver) Skip(data *pluginDriver.PluginDataType) error {
+	return nil
+}
+
+type mockFilterPluginDriver struct {
+	mockBasePluginDriver
+	filterFn func(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error)
+}
+
+func (m *mockFilterPluginDriver) Filter(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
+	return m.filterFn(data, retry)
+}
+
+func TestToServerApplyPluginFilterPassThrough(t *testing.T) {
+	s := &ToServer{}
+	input := &pluginDriver.PluginDataType{
+		EventType: "insert",
+		Rows: []map[string]interface{}{
+			{
+				"id":   1,
+				"name": "alice",
+			},
+		},
+	}
+	output, keep, err := s.applyPluginFilter(&mockBasePluginDriver{}, input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !keep {
+		t.Fatalf("expected keep=true")
+	}
+	if output != input {
+		t.Fatalf("expected same data pointer for pass-through")
+	}
+}
+
+func TestToServerApplyPluginFilterDynamicFields(t *testing.T) {
+	s := &ToServer{}
+	input := &pluginDriver.PluginDataType{
+		EventType: "insert",
+		Rows: []map[string]interface{}{
+			{
+				"id":         1,
+				"name":       "alice",
+				"drop_field": "x",
+			},
+		},
+	}
+	driver := &mockFilterPluginDriver{
+		filterFn: func(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
+			row := map[string]interface{}{
+				"id":        data.Rows[0]["id"],
+				"name":      data.Rows[0]["name"],
+				"new_field": "from-filter",
+			}
+			newData := *data
+			newData.Rows = []map[string]interface{}{row}
+			return &newData, true, nil
+		},
+	}
+	output, keep, err := s.applyPluginFilter(driver, input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !keep {
+		t.Fatalf("expected keep=true")
+	}
+	if _, ok := output.Rows[0]["drop_field"]; ok {
+		t.Fatalf("drop_field should be removed by filter plugin")
+	}
+	if output.Rows[0]["new_field"] != "from-filter" {
+		t.Fatalf("new_field not added by filter plugin")
+	}
+}
+
+func TestToServerApplyPluginFilterDropEvent(t *testing.T) {
+	s := &ToServer{}
+	input := &pluginDriver.PluginDataType{
+		EventType: "insert",
+		Rows:      []map[string]interface{}{{"id": 1}},
+	}
+	driver := &mockFilterPluginDriver{
+		filterFn: func(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
+			return nil, false, nil
+		},
+	}
+	_, keep, err := s.applyPluginFilter(driver, input, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if keep {
+		t.Fatalf("expected keep=false")
+	}
+}
+
+func TestToServerApplyPluginFilterKeepTrueButNilData(t *testing.T) {
+	s := &ToServer{}
+	input := &pluginDriver.PluginDataType{
+		EventType: "insert",
+		Rows:      []map[string]interface{}{{"id": 1}},
+	}
+	driver := &mockFilterPluginDriver{
+		filterFn: func(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
+			return nil, true, nil
+		},
+	}
+	_, _, err := s.applyPluginFilter(driver, input, false)
+	if err == nil {
+		t.Fatalf("expected error when keep=true but data=nil")
+	}
+}
+
+func TestToServerApplyPluginFilterReturnError(t *testing.T) {
+	s := &ToServer{}
+	input := &pluginDriver.PluginDataType{
+		EventType: "insert",
+		Rows:      []map[string]interface{}{{"id": 1}},
+	}
+	driver := &mockFilterPluginDriver{
+		filterFn: func(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
+			return data, true, errors.New("filter failed")
+		},
+	}
+	_, _, err := s.applyPluginFilter(driver, input, false)
+	if err == nil {
+		t.Fatalf("expected filter error")
+	}
+}


### PR DESCRIPTION
# feat: 支持 filter 插件动态字段过滤 (#220)

## 关联 Issue

Closes #220

## 背景

当前 ToServer 流程仅支持通过 FieldList 做静态字段保留，以及 FilterUpdate/FilterQuery 等固定策略。这导致插件无法在同步前按业务规则动态增删字段，也无法在插件内决定直接丢弃某条事件。

为满足 issue #220，需要在不破坏现有插件兼容性的前提下，增加可选的 filter 插件钩子能力。

## 改动概览

本次改动在 sendToServer 流程中增加"可选 filter 钩子"：

```
filterField（原有） → applyPluginFilter（新增，可选） → Insert/Update/Del/Query/Commit（原有）
```

### 1. 新增可选过滤接口

**新增文件**：`plugin/driver/filter_interface.go`

**新增接口**：

```go
type FilterPluginDriver interface {
    Filter(data *PluginDataType, retry bool) (newData *PluginDataType, keep bool, err error)
}
```

语义约定：

- `keep=false`：丢弃当前事件（视为成功跳过）
- `keep=true`：继续同步
- `keep=true` 时 `newData` 必须非空

### 2. 保持兼容：提供默认透传实现

**修改文件**：`plugin/driver/driver_interface.go`

在 `PluginDriverInterface` 增加默认 `Filter` 方法，默认返回 `(data, true, nil)`。

效果：

- 旧插件无需改动即可继续工作
- 只有显式实现 `FilterPluginDriver` 的插件才会启用动态过滤逻辑

### 3. 在发送链路接入过滤钩子

**修改文件**：`server/to_server_consume.go`

**新增方法**：`applyPluginFilter(conn, data, retry)`

处理逻辑：

- 插件未实现 `FilterPluginDriver`：直接透传
- `Filter` 返回错误：向上返回错误，沿用现有重试/错误处理链路
- `keep=false`：跳过该事件并返回成功（推进位点）
- `keep=true && newData==nil`：返回错误，防止空数据进入下游

## 使用示例

### 示例：实现一个动态过滤插件

```go
package myplugin

import pluginDriver "github.com/brokercap/Bifrost/plugin/driver"

type MyFilterPlugin struct {
    pluginDriver.PluginDriverInterface
}

// 实现 FilterPluginDriver 接口
func (p *MyFilterPlugin) Filter(data *pluginDriver.PluginDataType, retry bool) (*pluginDriver.PluginDataType, bool, error) {
    // 示例 1：删除敏感字段
    delete(data.Rows[0], "password")
    delete(data.Rows[0], "secret_key")
    
    // 示例 2：添加计算字段
    data.Rows[0]["processed_at"] = time.Now().Unix()
    
    // 示例 3：根据条件丢弃事件
    if status, ok := data.Rows[0]["status"].(string); ok && status == "deleted" {
        return nil, false, nil // keep=false，丢弃该事件
    }
    
    return data, true, nil // keep=true，继续同步
}
```

## 测试

**新增文件**：`server/to_server_consume_filter_test.go`

新增 5 个测试场景：

1. 插件未实现 filter 接口时透传
2. 动态字段变更（删除字段 + 新增字段）
3. `keep=false` 丢弃事件
4. `keep=true` 但返回 nil data 报错
5. Filter 显式返回错误

### 执行结果

```bash
go test ./server -run TestToServerApplyPluginFilter -count=1
```

通过。

```bash
go test ./plugin/driver -count=1
```

通过。

## 兼容性与风险

- **兼容性**：向后兼容，未实现过滤接口的插件行为不变
- **风险控制**：
  - 对 `keep=true && newData=nil` 做显式保护
  - 过滤接口采用可选 type assertion，不影响现有 Driver 主接口

## 变更文件

| 文件 | 变更说明 |
|------|----------|
| `plugin/driver/filter_interface.go` | 新增：定义 FilterPluginDriver 接口 |
| `plugin/driver/driver_interface.go` | 修改：增加默认 Filter 透传实现 |
| `server/to_server_consume.go` | 修改：新增 applyPluginFilter 方法，集成到发送链路 |
| `server/to_server_consume_filter_test.go` | 新增：过滤功能单元测试 |

## Summary

- Problem: ToServer only supports static FieldList filtering; plugins cannot dynamically add/remove fields or drop events before sync.
- What changed: Added optional FilterPluginDriver interface with default pass-through implementation; integrated filter hook into sendToServer flow.
- What did NOT change: Existing plugins without Filter implementation continue to work unchanged; core field list config (FieldList, FilterUpdate, FilterQuery) remains intact.

## Change Type

- [x] Feature

## Scope

- [x] Trading engine / strategies
- [x] API / server

## Linked Issues

- Closes #220

## Testing

- [x] Unit tests added for filter pass-through, field mutation, drop-event, and error cases
- [x] `go test ./server -run TestToServerApplyPluginFilter` passes
- [x] `go test ./plugin/driver` passes

## Security Impact

- Secrets/keys handling changed? **No**
- New/changed API endpoints? **No**
- User input validation affected? **No**

## Compatibility

- Backward compatible? **Yes** - plugins without Filter implementation work unchanged
- Config/env changes? **No**
- Migration needed? **No**
